### PR TITLE
[Update] Change AssemblyName property

### DIFF
--- a/Dockerfile.publicsite
+++ b/Dockerfile.publicsite
@@ -23,5 +23,5 @@ FROM mcr.microsoft.com/dotnet/aspnet:7.0
 WORKDIR /app
 
 COPY --from=build-env /app/out .
-ENTRYPOINT [ "dotnet", "Server.dll" ]
+ENTRYPOINT [ "dotnet", "SmallsOnline.Web.PublicSite.Server.dll" ]
 EXPOSE 80

--- a/src/SmallsOnline.Web.PublicSite/Client/Client.csproj
+++ b/src/SmallsOnline.Web.PublicSite/Client/Client.csproj
@@ -5,6 +5,7 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <RootNamespace>SmallsOnline.Web.PublicSite.Client</RootNamespace>
+        <AssemblyName>SmallsOnline.Web.PublicSite.Client</AssemblyName>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/SmallsOnline.Web.PublicSite/Server/Server.csproj
+++ b/src/SmallsOnline.Web.PublicSite/Server/Server.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>SmallsOnline.Web.PublicSite.Server</RootNamespace>
+    <AssemblyName>SmallsOnline.Web.PublicSite.Server</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/SmallsOnline.Web.PublicSite/Shared/Shared.csproj
+++ b/src/SmallsOnline.Web.PublicSite/Shared/Shared.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>SmallsOnline.Web.PublicSite.Shared</RootNamespace>
+    <AssemblyName>SmallsOnline.Web.PublicSite.Shared</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The `AssemblyName` property is now properly set after simplifying the main project file names.