### PR TITLE
Fix blog page scroll on navigation

### DIFF
--- a/src/PublicSite/Server/wwwroot/blazor.startup.js
+++ b/src/PublicSite/Server/wwwroot/blazor.startup.js
@@ -1,11 +1,16 @@
 Blazor.addEventListener('enhancedload', () => {
     hljs.highlightAll();
-    
-    let pageContentElement = document.getElementById("pagecontent");
 
-    pageContentElement.classList.add("fade-slide-in");
-    
-    pageContentElement.addEventListener("animationend", () => {
-        pageContentElement.classList.remove("fade-slide-in");
-    }, { once: true });
+    if (window.location.hash === "") {
+        let pageContentElement = document.getElementById("pagecontent");
+
+        pageContentElement.classList.add("fade-slide-in");
+
+        pageContentElement.addEventListener("animationend", () => {
+            pageContentElement.classList.remove("fade-slide-in");
+        }, { once: true });
+
+        console.log("Scrolling to top");
+        window.scrollTo(0, 0);
+    }
 });


### PR DESCRIPTION
When opening a blog post, the page will scroll back up to the top whenever no hash/anchor is in the URL.