### PR TITLE
Update VSCode tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -103,6 +103,33 @@
 			},
 			"problemMatcher": "$msCompile"
 		},
+		{
+			"label": "Run init tasks",
+			"detail": "Run init tasks for a web project.",
+			"icon": {
+				"id": "arrow-down",
+				"color": "terminal.ansiGreen"
+			},
+			"type": "process",
+			"command": "dotnet",
+			"args": [
+				"msbuild",
+				"-target:\"InitProject_Combined\""
+			],
+			"options": {
+				"cwd": "${workspaceFolder}/${input:initProject}",
+			},
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": false,
+				"panel": "shared",
+				"showReuseMessage": true,
+				"clear": true,
+				"close": true
+			},
+			"problemMatcher": "$msCompile"
+		},
 		// Remaining tasks are only for the VSCode launch configs
 		// or are supporting tasks.
 		{
@@ -210,6 +237,22 @@
 		{
 			"id": "watchProject",
 			"description": "Select a project to run 'dotnet watch' on.",
+			"type": "pickString",
+			"default": "src/PublicSite/Server",
+			"options": [
+				{
+					"label": "PublicSite: Server",
+					"value": "src/PublicSite/Server"
+				},
+				{
+					"label": "AdminSite: Server",
+					"value": "src/AdminSite/Server"
+				}
+			]
+		},
+		{
+			"id": "initProject",
+			"description": "Select a project to run init tasks on.",
 			"type": "pickString",
 			"default": "src/PublicSite/Server",
 			"options": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -63,6 +63,15 @@
 			"options": {
 				"cwd": "${workspaceFolder}"
 			},
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": false,
+				"panel": "shared",
+				"showReuseMessage": true,
+				"clear": true,
+				"close": true
+			},
 			"problemMatcher": "$msCompile"
 		},
 		{
@@ -83,6 +92,15 @@
 			"options": {
 				"cwd": "${workspaceFolder}"
 			},
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": false,
+				"panel": "shared",
+				"showReuseMessage": true,
+				"clear": true,
+				"close": true
+			},
 			"problemMatcher": "$msCompile"
 		},
 		{
@@ -100,6 +118,15 @@
 			],
 			"options": {
 				"cwd": "${workspaceFolder}"
+			},
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": false,
+				"panel": "shared",
+				"showReuseMessage": true,
+				"clear": true,
+				"close": true
 			},
 			"problemMatcher": "$msCompile"
 		},


### PR DESCRIPTION
- Adds task for running the `InitProject_Combined` target on **PublicSite** and **AdminSite** projects.
- Automatically close the task panel for most tasks.