### PR TITLE
Remove interactive server render mode from public site

### DIFF
--- a/src/PublicSite/Server/Program.cs
+++ b/src/PublicSite/Server/Program.cs
@@ -15,7 +15,6 @@ builder.Services
 // Add services to the container.
 builder.Services
     .AddRazorComponents()
-    .AddInteractiveServerComponents()
     .AddInteractiveWebAssemblyComponents();
 
 builder.Services
@@ -61,7 +60,6 @@ app.UseStaticFiles();
 
 app
     .MapRazorComponents<App>()
-    .AddInteractiveServerRenderMode()
     .AddInteractiveWebAssemblyRenderMode();
 
 app.MapRazorPages();

--- a/src/PublicSite/Server/Shared/Sidebar/SidebarItem.razor
+++ b/src/PublicSite/Server/Shared/Sidebar/SidebarItem.razor
@@ -9,7 +9,7 @@
         <div class="card-body">
             <div class="d-flex justify-content-center">
                 <div class="flex-shrink-1">
-                    <SidebarProfileImgWasm LoggingEnabled="@_isDevelopmentMode" @rendermode="@(new InteractiveAutoRenderMode(true))" />
+                    <SidebarProfileImgWasm LoggingEnabled="@_isDevelopmentMode" @rendermode="@(new InteractiveWebAssemblyRenderMode(true))" />
                 </div>
             </div>
             <div class="row justify-content-center gx-0 mt-4">


### PR DESCRIPTION
Removing interactive server rendering from the site since it's not used. Only one component _technically_ had it enabled through the auto render mode, but it ultimately renders with WebAssembly in the end anyway. That component now just renders as WebAssembly right out the gate.