### PR TITLE
Disable sticky header on blog

### DIFF
--- a/src/Css/bootstrap-custom.css
+++ b/src/Css/bootstrap-custom.css
@@ -31,6 +31,11 @@
     backdrop-filter: blur(50px);
 }
 
+.page-card-header-no-sticky {
+    -webkit-backdrop-filter: blur(50px);
+    backdrop-filter: blur(50px);
+}
+
 .page-card-body {
     z-index: 2;
 }

--- a/src/Lib.Components/Components/Blog/BlogEntryCard.razor
+++ b/src/Lib.Components/Components/Blog/BlogEntryCard.razor
@@ -6,7 +6,7 @@
 {
     <article>
         <div class="card page-card shadow">
-            <div class="card-header page-card-header">
+            <div class="card-header page-card-header-no-sticky">
                 <div class="mb-0">
                     <h1>
                         @if (BlogEntry.Title is not null)

--- a/src/PublicSite/Server/Pages/BlogEntryPage.razor
+++ b/src/PublicSite/Server/Pages/BlogEntryPage.razor
@@ -70,7 +70,7 @@ else
     <div class="row pb-2">
         <div class="col">
             <div class="card page-card shadow">
-                <div class="card-header page-card-header">
+                <div class="card-header page-card-header-no-sticky">
                     <div class="mb-0">
                         <div class="d-flex">
                             <div class="flex-grow-1">


### PR DESCRIPTION
The sticky header for blogs isn't all that helpful. Takes up too much space.