### PR TITLE
Optimize container images

### DIFF
--- a/Dockerfile.adminsite
+++ b/Dockerfile.adminsite
@@ -6,18 +6,14 @@ RUN apt-get update; \
     apt-get install -y ca-certificates curl gnupg; \
     mkdir -p /etc/apt/keyrings; \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
+    apt-get update; \
+    apt-get install -y nodejs python3 libc++1 libatomic1; \
+    curl -qL https://www.npmjs.com/install.sh | sh ;\
+    apt-get clean
 
-RUN apt-get update; \
-    apt-get install -y nodejs python3 libc++1 libatomic1
-
-# Temporary workaround for installing the bleeding edge release of .NET 8
-# RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 8.0 --quality daily --no-cdn --install-dir /usr/share/dotnet/; \
-#    dotnet --version
-
-RUN curl -qL https://www.npmjs.com/install.sh | sh
-
-RUN dotnet tool install --global PowerShell
+RUN dotnet tool install --global PowerShell; \
+    dotnet workload install wasm-tools
 
 WORKDIR /app
 COPY ./cleanBuildOutput.ps1 ./
@@ -28,19 +24,11 @@ COPY ./src/Lib.Components/ ./src/Lib.Components/
 COPY ./src/Lib.Services/ ./src/Lib.Services/
 COPY ./src/AdminSite/ ./src/AdminSite/
 
-RUN dotnet workload install wasm-tools
+RUN dotnet msbuild ./src/AdminSite/Server/ -t:"InitProject_Combined"; \
+    dotnet restore ./src/AdminSite/Server/; \
+    dotnet publish ./src/AdminSite/Server/ --configuration Release --output out
 
-RUN dotnet msbuild ./src/AdminSite/Server/ -t:"InitProject_Combined"
-RUN dotnet restore ./src/AdminSite/Server/
-RUN dotnet publish ./src/AdminSite/Server/ --configuration Release --output out
-
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
-
-# Temporary workaround for installing the bleeding edge release of .NET 8
-# RUN apt-get update; \
-#    apt-get install -y curl
-# RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 8.0 --quality daily --no-cdn --install-dir /usr/share/dotnet/; \
-#    dotnet --version
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled
 
 WORKDIR /app
 

--- a/Dockerfile.publicsite
+++ b/Dockerfile.publicsite
@@ -6,19 +6,18 @@ RUN apt-get update; \
     apt-get install -y ca-certificates curl gnupg; \
     mkdir -p /etc/apt/keyrings; \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-
-RUN apt-get update; \
-    apt-get install -y nodejs python3 libc++1 libatomic1
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
+    apt-get update; \
+    apt-get install -y nodejs python3 libc++1 libatomic1; \
+    curl -qL https://www.npmjs.com/install.sh | sh ;\
+    apt-get clean
 
 # Temporary workaround for installing the bleeding edge release of .NET 8
 # RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 8.0 --quality daily --no-cdn --install-dir /usr/share/dotnet/; \
 #    dotnet --version
 
-RUN curl -qL https://www.npmjs.com/install.sh | sh
-
-RUN dotnet tool install --global PowerShell
-RUN dotnet workload install wasm-tools
+RUN dotnet tool install --global PowerShell; \
+    dotnet workload install wasm-tools
 
 WORKDIR /app
 COPY ./cleanBuildOutput.ps1 ./
@@ -29,9 +28,9 @@ COPY ./src/Lib.Components/ ./src/Lib.Components/
 COPY ./src/Lib.Services/ ./src/Lib.Services/
 COPY ./src/PublicSite/ ./src/PublicSite/
 
-RUN dotnet msbuild ./src/PublicSite/Server/ -t:"InitProject_Combined"
-RUN dotnet restore ./src/PublicSite/Server/
-RUN dotnet publish ./src/PublicSite/Server/ --configuration Release --output out
+RUN dotnet msbuild ./src/PublicSite/Server/ -t:"InitProject_Combined"; \
+    dotnet restore ./src/PublicSite/Server/; \
+    dotnet publish ./src/PublicSite/Server/ --configuration Release --output out
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
 

--- a/Dockerfile.publicsite
+++ b/Dockerfile.publicsite
@@ -12,10 +12,6 @@ RUN apt-get update; \
     curl -qL https://www.npmjs.com/install.sh | sh ;\
     apt-get clean
 
-# Temporary workaround for installing the bleeding edge release of .NET 8
-# RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 8.0 --quality daily --no-cdn --install-dir /usr/share/dotnet/; \
-#    dotnet --version
-
 RUN dotnet tool install --global PowerShell; \
     dotnet workload install wasm-tools
 
@@ -33,12 +29,6 @@ RUN dotnet msbuild ./src/PublicSite/Server/ -t:"InitProject_Combined"; \
     dotnet publish ./src/PublicSite/Server/ --configuration Release --output out
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled
-
-# Temporary workaround for installing the bleeding edge release of .NET 8
-# RUN apt-get update; \
-#    apt-get install -y curl
-# RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 8.0 --quality daily --no-cdn --install-dir /usr/share/dotnet/; \
-#    dotnet --version
 
 WORKDIR /app
 

--- a/Dockerfile.publicsite
+++ b/Dockerfile.publicsite
@@ -32,7 +32,7 @@ RUN dotnet msbuild ./src/PublicSite/Server/ -t:"InitProject_Combined"; \
     dotnet restore ./src/PublicSite/Server/; \
     dotnet publish ./src/PublicSite/Server/ --configuration Release --output out
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled
 
 # Temporary workaround for installing the bleeding edge release of .NET 8
 # RUN apt-get update; \


### PR DESCRIPTION
Switching to the `aspnet:8.0-jammy-chiseled` image to reduce the final output size of the container images.