### PR TITLE
Fix mismatched types for ID properties from Odesli

### DIFF
--- a/src/Lib.Services/JsonSourceGen/OdesliJsonContext.cs
+++ b/src/Lib.Services/JsonSourceGen/OdesliJsonContext.cs
@@ -16,8 +16,6 @@ namespace SmallsOnline.Web.Lib.Services;
 [JsonSerializable(typeof(PlatformEntityLink))]
 [JsonSerializable(typeof(MusicEntityItem))]
 [JsonSerializable(typeof(MusicEntityItem[]))]
-[JsonSerializable(typeof(Dictionary<string, IPlatformEntityLink>))]
-[JsonSerializable(typeof(Dictionary<string, IStreamingEntityItem>))]
 [JsonSerializable(typeof(Dictionary<string, PlatformEntityLink>))]
 [JsonSerializable(typeof(Dictionary<string, StreamingEntityItem>))]
 internal partial class OdesliJsonContext : JsonSerializerContext

--- a/src/Lib/Models/Json/NumberToStringConverter.cs
+++ b/src/Lib/Models/Json/NumberToStringConverter.cs
@@ -1,0 +1,25 @@
+
+namespace SmallsOnline.Web.Lib.Models.Json;
+
+public class NumberToStringConverter : JsonConverter<string>
+{
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            return reader.GetString();
+        }
+
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            return reader.GetDouble().ToString();
+        }
+
+        throw new JsonException("Expected number or string.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value);
+    }
+}

--- a/src/Lib/Models/Odesli/StreamingEntityItem.cs
+++ b/src/Lib/Models/Odesli/StreamingEntityItem.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using SmallsOnline.Web.Lib.Models.Json;
 
 namespace SmallsOnline.Web.Lib.Models.Odesli;
 
@@ -9,6 +10,7 @@ public class StreamingEntityItem : IStreamingEntityItem
 {
     /// <inheritdoc cref="IStreamingEntityItem.Id" />
     [JsonPropertyName("id")]
+    [JsonConverter(typeof(NumberToStringConverter))]
     public string? Id { get; set; }
 
     /// <inheritdoc cref="IStreamingEntityItem.Title" />


### PR DESCRIPTION
## Description

This PR fixes an issue with the `id` property of `StreamingEntityItem` class when deserializing from JSON. _Sometimes_ it can be as a _"number"_ or a _"string"_.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement/Update
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
