### PR TITLE
Fix container image build missing centrally managed packages

### DIFF
--- a/Dockerfile.adminsite
+++ b/Dockerfile.adminsite
@@ -18,6 +18,7 @@ RUN dotnet tool install --global PowerShell; \
 WORKDIR /app
 COPY ./SmallsOnline.Web.sln ./
 COPY ./Directory.Build.props ./
+COPY ./Directory.Packages.props ./
 COPY ./global.json ./
 COPY ./cleanBuildOutput.ps1 ./
 COPY ./nuget.config /

--- a/Dockerfile.publicsite
+++ b/Dockerfile.publicsite
@@ -18,6 +18,7 @@ RUN dotnet tool install --global PowerShell; \
 WORKDIR /app
 COPY ./SmallsOnline.Web.sln ./
 COPY ./Directory.Build.props ./
+COPY ./Directory.Packages.props ./
 COPY ./global.json ./
 COPY ./cleanBuildOutput.ps1 ./
 COPY ./nuget.config /


### PR DESCRIPTION
## Description

This PR fixes the container images missing the `Directory.Packages.props` files in the build.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement/Update
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None
